### PR TITLE
Add contributor documentation and AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+For LLMs and other automations:
+- Start with `docs/contributors/README.md` for project overview, architecture notes, and links to all contributor docs.
+- Follow the conventions in that folder (workflow, pull requests, file layout, styles, component docs) before making changes or responding.

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -1,0 +1,22 @@
+# Contributor Guide
+
+Superdef UI (SDFUI) is a React + TypeScript Material Design 3 component library. Components are authored with SCSS modules and build-time tokens, packaged with Rollup for library consumers, and developed/tested via Vite + Jest.
+
+## Architecture at a Glance
+- **Library-first exports:** `src/index.ts` re-exports components, hooks, theme utilities, and the `buildClassName` helper; `rollup.config.mjs` builds CJS/ESM bundles and extracts CSS modules.
+- **Theming:** `ConfigProvider` exposes `appearance` via `ThemeContext` and components pass `light`/`dark` class names through to trigger the CSS custom properties declared in `src/index.module.scss`.
+- **Styling:** SCSS modules are compiled to camelCase classnames; shared utility styles live in `src/core/styles/ui.module.scss`; component styles rely on the design tokens in `src/index.module.scss` and `buildClassName` to compose classes.
+- **Responsiveness:** Layout/spacings accept `AdaptiveValue` inputs and resolve through `useAdaptiveValue` + `useMediaScreenSize` in `src/hooks/media.ts`.
+- **Developer tooling:** Vite powers the playground (`src/App.tsx`) and Jest + Testing Library cover unit tests alongside components.
+
+## What to Read
+- `docs/contributors/conventions/README.md` — index of workflow, PR, style, and file layout conventions.
+- `docs/contributors/conventions/file.md` — current file/folder layout and what lives where.
+- `docs/contributors/conventions/workflow.md` — how tasks are tracked in GitHub issues/projects.
+- `docs/contributors/conventions/pullRequest.md` — PR title/body patterns and squash-merge expectations.
+- `docs/contributors/conventions/styles.md` — styling and theme token expectations for new work.
+- `docs/contributors/components/README.md` — how to document components in this folder.
+- `docs/contributors/components/Button.md` — reference component doc example.
+- `docs/contributors/hooks/README.md` — notes on documenting contributor-facing hooks.
+
+Refer back here whenever adding components, hooks, or docs to keep the documentation consistent.

--- a/docs/contributors/components/Button.md
+++ b/docs/contributors/components/Button.md
@@ -1,0 +1,33 @@
+# Button
+
+Material Design 3 button with built-in ripple feedback and variant-based styling. Respects the current theme appearance (`light`/`dark`) provided by `ConfigProvider`.
+
+## Props
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `variant` | `"elevated", "filled", "filled-tonal", "outlined", "text"` | `"filled"` | Chooses the MD3 treatment and token set. Unknown values fall back to `filled` because of the lookup default. |
+| `icon` | `React.ReactNode` | — | When provided, renders to the left of the label with adjusted padding. |
+| `children` | `React.ReactNode` | — | Button label/content. |
+| `className` / `style` | From `HTMLButtonElement` | — | Merged onto the root `<button>`. |
+| `onClick` and other button props | From `HTMLButtonElement` | — | Additional attributes are forwarded through `cleanedProps`. |
+
+## Usage
+```tsx
+import { Button, ConfigProvider } from "@nacteam/sdfui";
+
+export const Actions = () => (
+  <ConfigProvider>
+    <div className="app light">
+      <Button variant="filled" onClick={() => console.log("save")}>Save</Button>
+      <Button variant="outlined" icon={<IconSave />}>
+        Save draft
+      </Button>
+    </div>
+  </ConfigProvider>
+);
+```
+
+## Styling Notes
+- Styles live in `src/components/Button/Button.module.scss` and use CSS custom properties from `src/index.module.scss` for MD3 color/elevation tokens.
+- The component composes class names with `buildClassName` to combine the variant style, current `appearance`, optional icon class, the shared `translucentSurface` style, and any user `className`.
+- A `Ripple` overlay is included to provide pressed feedback; keep it as the last child inside the button.

--- a/docs/contributors/components/README.md
+++ b/docs/contributors/components/README.md
@@ -1,0 +1,11 @@
+# Component Docs Format
+
+Use this folder to document each exported component. Follow the same outline for consistency:
+
+1. **Overview:** What the component does and any design constraints (e.g., MD3 alignment, reliance on theme tokens).
+2. **Props:** Table of props with types, defaults, and behavioral notes. Call out any HTML props passed through.
+3. **Usage:** Minimal JSX examples that include required providers (e.g., `ConfigProvider`) and show common variants.
+4. **Styling/behavior:** Describe how theme tokens, CSS modules, and helpers like `buildClassName` are applied, plus any responsive or adaptive props.
+5. **Testing expectations:** Mention existing test coverage and what to add when changing behavior.
+
+Add one `.md` file per component (e.g., `Button.md`) and keep code snippets small and runnable.

--- a/docs/contributors/conventions/README.md
+++ b/docs/contributors/conventions/README.md
@@ -1,0 +1,9 @@
+# Conventions Index
+
+Use these documents to keep contributions consistent with the current architecture and workflow:
+- `file.md` — directory layout and where to place new code/docs.
+- `workflow.md` — how work is planned and linked to GitHub issues/projects.
+- `pullRequest.md` — PR title/body patterns, linking issues, and squash-merge expectations.
+- `styles.md` — styling, theme token, and responsiveness guidelines.
+
+Read these before opening or reviewing a PR that touches UI, build tooling, or docs.

--- a/docs/contributors/conventions/file.md
+++ b/docs/contributors/conventions/file.md
@@ -1,0 +1,29 @@
+# File Layout
+
+High-level map of the repository and what belongs where:
+
+```
+.
+├─ docs/
+│  ├─ hooks/                  # End-user hook docs (existing library docs)
+│  └─ contributors/           # Contributor-focused docs (this folder)
+├─ src/
+│  ├─ components/             # UI components, each with its own folder, styles, and tests
+│  ├─ core/
+│  │  ├─ theme/               # Theme context and system appearance detection
+│  │  ├─ styles/              # Shared style snippets (e.g., translucent surface)
+│  │  ├─ types/               # Shared types like AdaptiveValue
+│  │  └─ util/                # Small helpers such as class name builders
+│  ├─ hooks/                  # Reusable hooks (media queries, theme access)
+│  ├─ index.module.scss       # MD3 design tokens and theme CSS variables
+│  ├─ index.ts                # Library entrypoint exporting components/hooks/theme/types/utils
+│  └─ App.tsx                 # Vite playground/demo for local development
+├─ dist/                      # Build artifacts (CJS/ESM bundles, types) produced by Rollup
+├─ rollup.config.mjs          # Library build pipeline
+├─ vite.config.ts             # Playground/dev server config
+├─ jest.config.cjs            # Unit test config (Jest + Testing Library)
+├─ package.json               # Scripts, dependencies, package metadata
+└─ AGENTS.md                  # Pointer for LLMs/automation to contributor docs
+```
+
+Add new components/hooks under `src/` with colocated styles and tests; export them through `src/index.ts` so they ship in the library build.

--- a/docs/contributors/conventions/pullRequest.md
+++ b/docs/contributors/conventions/pullRequest.md
@@ -1,0 +1,10 @@
+# Pull Request Guidelines
+
+- **Title:** Use `<area>: <imperative summary>` (e.g., `docs: add contributor architecture notes`, `button: fix ripple timing`). Keep it concise and issue-focused.
+- **Description:** Include:
+  - What changed and why (one to three bullets).
+  - Testing performed (`npm test`, manual steps, or `not run`).
+  - Issue linkage (`Closes #<issue-number>`).
+- **Commits:** Squash before merge; maintainers use squash-merge on GitHub so individual commits are not required to be perfect.
+- **Scope:** Keep PRs narrowly scoped; split features/docs/refactors into separate PRs when possible.
+- **Reviews:** Request review when tests pass and the description is complete; address comments with follow-up commits before squash.

--- a/docs/contributors/conventions/styles.md
+++ b/docs/contributors/conventions/styles.md
@@ -1,0 +1,8 @@
+# Styling Conventions
+
+- **CSS Modules:** Author component styles in `.module.scss` files; classes compile to camelCase in TypeScript. Avoid global selectors unless adding theme-level tokens.
+- **Theme tokens:** Use CSS custom properties defined in `src/index.module.scss` (colors, elevation, shapes). Components should render with both `light` and `dark` appearance classes applied to a parent container.
+- **Class composition:** Combine module classes with `buildClassName` to keep ordering predictable. Shared utilities (e.g., `translucentSurface`) live in `src/core/styles/ui.module.scss`.
+- **Adaptive spacing/layout:** Accept `AdaptiveValue` props when sizing/margins can vary by breakpoint; resolve them with `useAdaptiveValue` and respect the breakpoints in `useMediaScreenSize`.
+- **Structure:** Keep styles colocated with components and keep variant-specific rules (`filled`, `outlined`, etc.) inside the same module file.
+- **Ripple/interaction:** Preserve focus/hover/pressed feedback used by existing components (e.g., `Ripple`), and ensure disabled states reflect MD3 token guidance.

--- a/docs/contributors/conventions/workflow.md
+++ b/docs/contributors/conventions/workflow.md
@@ -1,0 +1,6 @@
+# Workflow
+
+- Tasks are tracked as GitHub issues in the nacteam/sdfui project. Pick up work by claiming an issue and link your branch/PR back to it.
+- If work is not covered by an existing issue, create one with a short problem statement, scope, and acceptance criteria before opening a PR.
+- Keep issue statuses in sync with progress (e.g., via project board updates) so maintainers can see what is in flight.
+- Close issues through PRs (`Closes #<issue-number>`) to keep history tidy.

--- a/docs/contributors/hooks/README.md
+++ b/docs/contributors/hooks/README.md
@@ -1,0 +1,8 @@
+# Hook Docs Notes
+
+Use this folder to capture contributor-facing notes for hooks exposed by the library. For each hook, include:
+- What the hook returns and any dependencies (e.g., media queries, context requirements).
+- How it interacts with theme tokens or adaptive values.
+- Example usage focused on library authors (pairing hooks with components).
+
+End-user hook docs live in `docs/hooks/`; use this folder to document implementation details or contribution guidance.


### PR DESCRIPTION
## Summary
- add contributor guide with architecture snapshot and pointers to conventions
- document workflow, PR, file layout, styling conventions, and add a component doc example for Button
- add AGENTS.md to route LLMs/automations to the contributor docs

## Testing
- not run (docs only)

Closes #29